### PR TITLE
Make server configurable via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,17 @@ npm install
 ### 3. Colocar o banco de dados na pasta do servidor
 Copie o arquivo `acoditools.db` para a pasta `Server Node`.
 
-### 4. Iniciar o servidor
+### 4. Definir variáveis de ambiente (opcional)
+- `PORT`: porta utilizada pelo servidor (padrão `3000`).
+- `DB_FILE`: caminho para o arquivo SQLite (padrão `./acoditools.db`).
+
+### 5. Iniciar o servidor
 ```bash
 npm start
 ```
-O servidor será iniciado em `http://localhost:3000`.
+O servidor será iniciado em `http://localhost:3000` (ou na porta definida em `PORT`).
 
-### 5. Abrir o frontend
+### 6. Abrir o frontend
 Abra o arquivo `HTML Projeto/inicial/index.html` no navegador (pode usar Live Server).
 
 ---

--- a/Server Node/server.js
+++ b/Server Node/server.js
@@ -5,7 +5,7 @@ import { open } from 'sqlite';
 import cors from 'cors';
 
 const app = express();
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 
 app.use(cors());
 app.use(express.json());
@@ -14,7 +14,7 @@ let db;
 
 async function iniciarBanco() {
     db = await open({
-        filename: './acoditools.db',
+        filename: process.env.DB_FILE || './acoditools.db',
         driver: sqlite3.Database
     });
 


### PR DESCRIPTION
## Summary
- allow configuring server port and database file via environment variables
- document `PORT` and `DB_FILE` in the README

## Testing
- `npm install` within the server folder
- `PORT=4000 DB_FILE=./acoditools.db node server.js & sleep 3; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_684dfa8b43188323ad2f9072af3d8f9b