### PR TITLE
Update server auth to plain text passwords

### DIFF
--- a/Server Node/package-lock.json
+++ b/Server Node/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "sqlite": "^5.1.1",
@@ -183,29 +182,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/bcrypt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
-      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/bcrypt/node_modules/node-addon-api": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.4.0.tgz",
-      "integrity": "sha512-D9DI/gXHvVmjHS08SVch0Em8G5S1P+QWtU31appcKT/8wFSPRcdHadIFSAntdMMVM5zz+/DL+bL/gz3UDppqtg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -1493,17 +1469,6 @@
       },
       "engines": {
         "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nopt": {

--- a/Server Node/package.json
+++ b/Server Node/package.json
@@ -12,7 +12,6 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "sqlite": "^5.1.1",

--- a/Server Node/server.js
+++ b/Server Node/server.js
@@ -3,7 +3,6 @@ import express from 'express';
 import sqlite3 from 'sqlite3';
 import { open } from 'sqlite';
 import cors from 'cors';
-import bcrypt from 'bcrypt';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -38,11 +37,9 @@ app.post('/usuario', async (req, res) => {
             return res.status(409).json({ error: "Email já cadastrado." });
         }
 
-        const hashed = await bcrypt.hash(password, 10);
-
         const result = await db.run(
             'INSERT INTO usuarios (nome, email, password) VALUES (?, ?, ?)',
-            [nome, email, hashed]
+            [nome, email, password]
         );
 
         res.status(201).json({ id: result.lastID, nome, email });
@@ -65,8 +62,7 @@ app.post('/login', async (req, res) => {
             return res.status(401).json({ error: "Credenciais inválidas." });
         }
 
-        const valid = await bcrypt.compare(password, user.password);
-        if (!valid) {
+        if (user.password !== password) {
             return res.status(401).json({ error: "Credenciais inválidas." });
         }
 


### PR DESCRIPTION
## Summary
- remove bcrypt in server
- insert and verify passwords without hashing
- drop bcrypt from dependencies

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ee435b4b48323acf71fb55133db7b