### PR TITLE
Add admin bootstrap user

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ O servidor será iniciado em `http://localhost:3000` (ou na porta definida em `P
 ### 6. Abrir o frontend
 Abra o arquivo `HTML Projeto/inicial/index.html` no navegador (pode usar Live Server).
 
+### Usuário administrador padrão
+Ao iniciar o servidor é criado automaticamente um usuário administrador com:
+- **Email:** admin@emil.com
+- **Senha:** admin123
+
 ---
 
 ## 🔌 Rotas da API

--- a/Server Node/server.js
+++ b/Server Node/server.js
@@ -23,6 +23,20 @@ async function iniciarBanco() {
 
 await iniciarBanco();
 
+async function criarAdmin() {
+    const adminEmail = 'admin@emil.com';
+    const existente = await db.get('SELECT * FROM usuarios WHERE email = ?', [adminEmail]);
+    if (!existente) {
+        await db.run(
+            'INSERT INTO usuarios (nome, email, password) VALUES (?, ?, ?)',
+            ['admin', adminEmail, 'admin123']
+        );
+        console.log('Usuário admin criado');
+    }
+}
+
+await criarAdmin();
+
 // Rota: Cadastrar novo usuário
 app.post('/usuario', async (req, res) => {
     const { nome, email, password } = req.body;


### PR DESCRIPTION
## Summary
- ensure an admin user exists when the server starts
- document default admin credentials in the README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ee50360848323a1fa90bd33679ff9