### PR TITLE
Update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 
 ## 🚀 Como rodar o projeto localmente
 
+> **Nota:** as senhas deste projeto ficam salvas em *texto puro* no banco de dados. Utilize-o apenas para fins de estudo.
 ### 1. Clonar o repositório
 ```bash
 git clone https://github.com/JhonataRocha/fatec.git
@@ -31,8 +32,6 @@ cd fatec
 cd "Server Node"
 npm install
 ```
-Isso irá instalar todas as bibliotecas necessárias, incluindo o `bcrypt`,
-utilizado para proteger as senhas dos usuários.
 
 ### 3. Colocar o banco de dados na pasta do servidor
 Copie o arquivo `acoditools.db` para a pasta `Server Node`.


### PR DESCRIPTION
## Summary
- warn that passwords are stored in plain text
- drop mention of installing bcrypt
- keep admin default credentials so users can log in

## Testing
- `npm test --prefix 'Server Node'` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ee5dcce448323977f675b849b002c