### PR TITLE
Add DB setup script and update password field

### DIFF
--- a/HTML Projeto/Auditor/config_perfil.html
+++ b/HTML Projeto/Auditor/config_perfil.html
@@ -44,8 +44,8 @@
                 </div>
 
                 <div class="form-group password-group">
-                    <label for="senha">Senha Atual:</label>
-                    <input type="password" id="senha" name="senha" value="********" disabled>
+                    <label for="password">Senha Atual:</label>
+                    <input type="password" id="password" name="password" value="********" disabled>
                     <a href="#" class="btn-edit"><i class="fas fa-lock"></i> Alterar Senha</a>
                 </div>
 

--- a/HTML Projeto/JS/index.js
+++ b/HTML Projeto/JS/index.js
@@ -6,8 +6,8 @@ document.addEventListener("DOMContentLoaded", () => {
         loginForm.addEventListener("submit", function (event) {
             event.preventDefault();
             const email = document.getElementById("email").value.trim();
-            const senha = document.getElementById("senha").value;
-            handleLogin(email, senha);
+            const password = document.getElementById("password").value;
+            handleLogin(email, password);
         });
     }
 });

--- a/HTML Projeto/JS/login.js
+++ b/HTML Projeto/JS/login.js
@@ -1,9 +1,9 @@
 
 // login.js
 
-function handleLogin(email, senha) {
+function handleLogin(email, password) {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!email || !senha) {
+    if (!email || !password) {
         showToast('Por favor, preencha o email e a senha.');
         return;
     }
@@ -17,7 +17,7 @@ function handleLogin(email, senha) {
     fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password: senha })
+        body: JSON.stringify({ email, password })
     })
     .then(response => {
         if (response.ok) {

--- a/HTML Projeto/inicial/index.html
+++ b/HTML Projeto/inicial/index.html
@@ -19,8 +19,8 @@
                 <input type="email" id="email" name="email" required>
             </div>
             <div class="form-group">
-                <label for="senha">Senha</label>
-                <input type="password" id="senha" name="senha" required>
+                <label for="password">Senha</label>
+                <input type="password" id="password" name="password" required>
             </div>
             <button type="submit" class="btn-login">Entrar</button>
             <p id="mensagem-erro" style="color: red; display: none;">Usuário ou senha inválidos</p>

--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ cd "Server Node"
 npm install
 ```
 
-### 3. Colocar o banco de dados na pasta do servidor
-Copie o arquivo `acoditools.db` para a pasta `Server Node`.
+### 3. Criar o banco de dados
+Execute o script de inicialização para gerar `acoditools.db` na pasta `Server Node`:
+```bash
+npm run init-db
+```
 
 ### 4. Definir variáveis de ambiente (opcional)
 - `PORT`: porta utilizada pelo servidor (padrão `3000`).

--- a/Server Node/init_db.js
+++ b/Server Node/init_db.js
@@ -1,0 +1,72 @@
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+
+async function init() {
+    const db = await open({
+        filename: './acoditools.db',
+        driver: sqlite3.Database
+    });
+
+    const sql = `
+BEGIN TRANSACTION;
+CREATE TABLE IF NOT EXISTS achados (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    descricao VARCHAR(200) NOT NULL,
+    auditoria_id INTEGER NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    data DATE NOT NULL,
+    FOREIGN KEY (auditoria_id) REFERENCES auditorias(id)
+);
+CREATE TABLE IF NOT EXISTS auditorias (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    titulo VARCHAR(100) NOT NULL,
+    categoria VARCHAR(50) NOT NULL,
+    data DATE NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    usuario_id INTEGER,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id)
+);
+CREATE TABLE IF NOT EXISTS logs_acesso (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    usuario_id INTEGER,
+    data_acesso DATETIME DEFAULT CURRENT_TIMESTAMP,
+    acao VARCHAR(100),
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id)
+);
+CREATE TABLE IF NOT EXISTS usuarios (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    nome VARCHAR(100) NOT NULL,
+    email VARCHAR(100) UNIQUE NOT NULL,
+    password VARCHAR(100) NOT NULL
+);
+INSERT INTO "achados" ("id","descricao","auditoria_id","status","data") VALUES (1,'Senha padrão em uso no servidor web',1,'Aberto','2025-06-01'),
+ (2,'Usuário com acesso indevido a arquivos sensíveis',2,'Revisão','2025-06-02'),
+ (3,'Backup semanal não executado',3,'Corrigido','2025-06-03'),
+ (4,'Software desatualizado exposto na rede',4,'Aberto','2025-06-04'),
+ (5,'Política de senhas fraca detectada',5,'Aberto','2025-06-05');
+INSERT INTO "auditorias" ("id","titulo","categoria","data","status","usuario_id") VALUES (1,'Verificação de Firewall','Segurança','2025-06-01','Conforme',1),
+ (2,'Auditoria de Acesso','Acesso','2025-06-02','Não Conforme',3),
+ (3,'Backup Semanal','Infraestrutura','2025-06-03','Pendente',1),
+ (4,'Atualizações de Software','Manutenção','2025-06-04','Conforme',2),
+ (5,'Gestão de Senhas','Segurança','2025-06-05','Não Conforme',3);
+INSERT INTO "usuarios" ("id","nome","email","password") VALUES (1,'Jhonata Rocha de Oliveira','jhonata@email.com','123456'),
+ (2,'Caio Felipe Almeida','caio@email.com','senha123'),
+ (3,'Gabriel Henrique Caetano Sales','gabriel@email.com','admin123');
+COMMIT;
+`;
+
+    await db.exec(sql);
+
+    // add test user if not exists
+    const existing = await db.get('SELECT * FROM usuarios WHERE email = ?', ['teste@teste.com']);
+    if (!existing) {
+        await db.run('INSERT INTO usuarios (nome, email, password) VALUES (?, ?, ?)', ['Teste', 'teste@teste.com', '123456']);
+    }
+
+    await db.close();
+    console.log('Banco de dados criado com sucesso.');
+}
+
+init().catch(err => {
+    console.error('Erro ao criar banco:', err);
+});

--- a/Server Node/package.json
+++ b/Server Node/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node server.js",
+    "init-db": "node init_db.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- create `init_db.js` for creating the SQLite DB and seed data
- add npm script `init-db`
- update README with instructions to run `npm run init-db`
- standardize frontend variable names from `senha` to `password`

## Testing
- `npm run init-db`

------
https://chatgpt.com/codex/tasks/task_e_684ee93961848323a56230e7d1d5dbd5